### PR TITLE
Switch register_new_matrix_user command to use HTTP instead of HTTPS

### DIFF
--- a/matrix-synapse-easy-install.sh
+++ b/matrix-synapse-easy-install.sh
@@ -139,7 +139,7 @@ crontab /tmp/matrix-synapse-easy-install/cron
 rm -rf /tmp/matrix-synapse-easy-install
 echo "INFO - The static Matrix page should be up already at https://$DOMAIN";
 echo "INFO - Creating your first user (you probably want this to be an admin)";
-register_new_matrix_user -c /etc/matrix-synapse/conf.d/register.yaml https://127.0.0.1:8448
+register_new_matrix_user -c /etc/matrix-synapse/conf.d/register.yaml http://127.0.0.1:8448
 echo "INFO - Test if your server federates correctly at https://federationtester.matrix.org/#$DOMAIN"
 echo "OK - Matrix should be up and running. Nothing to do here!"
 echo "Thank you for using my script!"


### PR DESCRIPTION
I encountered this error and solved it with the following command: `register_new_matrix_user -c /etc/matrix-synapse/conf.d/register.yaml http://127.0.0.1:8448`.

```bash 
root@debian:~# register_new_matrix_user -c /etc/matrix-synapse/conf.d/register.yaml https://127.0.0.1:8448
New user localpart [root]: deneme
Password: 
Confirm password: 
Make admin [no]: y
Traceback (most recent call last):
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/connectionpool.py", line 466, in _make_request
    self._validate_conn(conn)
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/connectionpool.py", line 1095, in _validate_conn
    conn.connect()
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/connection.py", line 652, in connect
    sock_and_verified = _ssl_wrap_socket_and_match_hostname(
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/connection.py", line 805, in _ssl_wrap_socket_and_match_hostname
    ssl_sock = ssl_wrap_socket(
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 465, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/util/ssl_.py", line 509, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
  File "/usr/lib/python3.9/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.9/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/usr/lib/python3.9/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'. (_ssl.c:1123)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/connectionpool.py", line 789, in urlopen
    response = self._make_request(
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/connectionpool.py", line 490, in _make_request
    raise new_e
urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'. (_ssl.c:1123)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/requests/adapters.py", line 589, in send
    resp = conn.urlopen(
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/connectionpool.py", line 843, in urlopen
    retries = retries.increment(
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/urllib3/util/retry.py", line 519, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='127.0.0.1', port=8448): Max retries exceeded with url: /_synapse/admin/v1/register (Caused by SSLError(SSLCertVerificationError(1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'. (_ssl.c:1123)")))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/register_new_matrix_user", line 8, in <module>
    sys.exit(main())
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/synapse/_scripts/register_new_matrix_user.py", line 302, in main
    register_new_user(
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/synapse/_scripts/register_new_matrix_user.py", line 162, in register_new_user
    request_registration(
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/synapse/_scripts/register_new_matrix_user.py", line 60, in request_registration
    r = requests.get(url)
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/opt/venvs/matrix-synapse/lib/python3.9/site-packages/requests/adapters.py", line 620, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='127.0.0.1', port=8448): Max retries exceeded with url: /_synapse/admin/v1/register (Caused by SSLError(SSLCertVerificationError(1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'. (_ssl.c:1123)")))
```